### PR TITLE
Allow global table font size configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ python auto_generate_ppt_xlwings_final_v2.py ^
   --raw_table Raw_Data ^
   --out deck.pptx ^
   --link_mode overlay ^
-  --header_font_pt 12 ^
+  --table_font_pt 12 ^
   --verbose
 ```
 
@@ -63,7 +63,7 @@ python auto_generate_ppt_xlwings_final_v2.py ^
 - `--raw_table` : name of the Excel **Table** (ListObject) with raw data.
 - `--out` : output PPTX path.
 - `--link_mode` : `overlay` (transparent rectangles on top of each numeric cell; **default**) or `text` (hyperlink on the number text; no shapes).
-- `--header_font_pt` : header font size; smaller values help keep headers on one line.
+  - `--table_font_pt` : font size for table text (deprecated alias: `--header_font_pt`).
 - `--verbose` : print debug info (useful while wiring up a new workbook).
 
 ---


### PR DESCRIPTION
## Summary
- keep deprecated `--header_font_pt` as hidden alias for `--table_font_pt`
- document alias in README

## Testing
- `python auto_generate_ppt_xlwings_final_v2.py --help`
- `python auto_generate_ppt_xlwings_final_v2.py --header_font_pt 14 --help`
- `python -m py_compile auto_generate_ppt_xlwings_final_v2.py`


------
https://chatgpt.com/codex/tasks/task_e_6899c68490c483318f18ee8eac5783cb