### PR TITLE
Scale table row heights with font size

### DIFF
--- a/auto_generate_ppt_xlwings_final_v2.py
+++ b/auto_generate_ppt_xlwings_final_v2.py
@@ -350,12 +350,16 @@ def build_ppt_xlwings(xlsx_path: Path, out_path: Path, sheet_name: str, summary_
                     run.hyperlink.target_slide = target  # backup link
 
         # recompute actual grid
-        col_lefts = [int(left)]
+        table_left = int(table_shape.left)
+        table_top = int(table_shape.top)
+
+        col_lefts = [table_left]
         for j in range(1, sum_cols):
-            col_lefts.append(col_lefts[-1] + int(table.columns[j-1].width))
-        row_tops = [int(top)]
-        for i in range(1, sum_rows):
-            row_tops.append(row_tops[-1] + int(table.rows[i-1].height))
+            col_lefts.append(col_lefts[-1] + int(table.columns[j - 1].width))
+
+        row_tops = [table_top]
+        for i in range(sum_rows):
+            row_tops.append(row_tops[-1] + int(table.rows[i].height))
 
         # overlays in FRONT
         if link_mode == "overlay":
@@ -371,7 +375,7 @@ def build_ppt_xlwings(xlsx_path: Path, out_path: Path, sheet_name: str, summary_
                     x = col_lefts[j]
                     y = row_tops[i]
                     w = int(table.columns[j].width)
-                    h = int(table.rows[i].height)
+                    h = row_tops[i + 1] - row_tops[i]
                     add_overlay_link(summary_slide, x, y, w, h, target)
 
         prs.save(out_path)

--- a/auto_generate_ppt_xlwings_final_v2.py
+++ b/auto_generate_ppt_xlwings_final_v2.py
@@ -243,8 +243,16 @@ def build_ppt_xlwings(xlsx_path: Path, out_path: Path, sheet_name: str, summary_
         sum_cols = len(headers)
         sum_rows = len(summary) + 1
         left, top, width = Inches(0.5), Inches(1.5), Inches(9.5)
-        base_row_height = Inches(0.4)
-        table_shape = summary_slide.shapes.add_table(sum_rows, sum_cols, left, top, width, base_row_height * sum_rows)
+        # Derive a row height that scales with the font size.
+        # 0.4" works well for an 18pt font, so convert 0.4" to points and
+        # use that to compute a proportional height for the requested font size.
+        points_per_inch = 72
+        row_height_pt = (0.4 * points_per_inch / 18) * table_font_pt
+        base_row_height = Pt(row_height_pt)
+
+        table_shape = summary_slide.shapes.add_table(
+            sum_rows, sum_cols, left, top, width, base_row_height * sum_rows
+        )
         table = table_shape.table
 
         total_w = int(width)


### PR DESCRIPTION
## Summary
- Compute table row heights based on the configured font size instead of a fixed 0.4in.
- Ensure overlay links inherit the dynamically calculated row height.

## Testing
- `python -m py_compile auto_generate_ppt_xlwings_final_v2.py`
- `python auto_generate_ppt_xlwings_final_v2.py --help`


------
https://chatgpt.com/codex/tasks/task_e_689a0cd4d2808331947a11555c2e9a33