### PR TITLE
Scale table row heights with font size in text link mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ python auto_generate_ppt_xlwings_final_v2.py ^
 - `--key_header` : column used as the key in detail tables (e.g., `Product`). Defaults to the first column of the raw table.
 - `--out` : output PPTX path.
 - `--link_mode` : `text` (hyperlink on the number text; no shapes; **default**) or `overlay` (transparent rectangles on top of each numeric cell).
-  - `--table_font_pt` : font size for table text (deprecated alias: `--header_font_pt`).
+- `--table_font_pt` : font size for table text (deprecated alias: `--header_font_pt`). When `--link_mode` is `text`, row heights scale with this value (0.4" at 18pt).
 - `--round_digits` : decimal places for numeric values (default 2).
 - `--verbose` : print debug info (useful while wiring up a new workbook).
 

--- a/auto_generate_ppt_xlwings_final_v2.py
+++ b/auto_generate_ppt_xlwings_final_v2.py
@@ -270,7 +270,10 @@ def build_ppt_xlwings(xlsx_path: Path, out_path: Path, sheet_name: str, summary_
         sum_cols = len(headers)
         sum_rows = len(summary) + 1
         left, top, width = Inches(0.5), Inches(1.5), Inches(9.5)
-        base_row_height = Inches(0.4)
+        if link_mode == "text":
+            base_row_height = Inches(0.4 * table_font_pt / 18)
+        else:
+            base_row_height = Inches(0.4)
         table_shape = summary_slide.shapes.add_table(sum_rows, sum_cols, left, top, width, base_row_height * sum_rows)
         table = table_shape.table
 
@@ -337,7 +340,17 @@ def build_ppt_xlwings(xlsx_path: Path, out_path: Path, sheet_name: str, summary_
                 p3 = tf.add_paragraph(); p3.text = f"Evaluated value: {format_number(info['value'], round_digits)}"; p3.level = 1;p3.font.size = Pt(14)
                 # Snippet
                 rows, cols = df_snippet.shape
-                s_table = slide.shapes.add_table(rows+1, cols, Inches(0.5), Inches(2.6), Inches(9.2), Inches(0.6 + 0.3*max(rows,1))).table
+                if link_mode == "text":
+                    snip_row_height = Inches(0.4 * table_font_pt / 18)
+                    snip_height = snip_row_height * (rows + 1)
+                else:
+                    snip_height = Inches(0.6 + 0.3*max(rows,1))
+                    snip_row_height = None
+                s_table_shape = slide.shapes.add_table(rows+1, cols, Inches(0.5), Inches(2.6), Inches(9.2), snip_height)
+                s_table = s_table_shape.table
+                if snip_row_height is not None:
+                    for rr in range(rows+1):
+                        s_table.rows[rr].height = int(snip_row_height)
                 for jj, hh in enumerate(df_snippet.columns):
                     tfh = s_table.cell(0, jj).text_frame; tfh.clear()
                     r0 = tfh.paragraphs[0].add_run(); r0.text = str(hh); r0.font.bold = True; r0.font.size = Pt(table_font_pt)


### PR DESCRIPTION
## Summary
- Adjust summary and detail table row heights based on `--table_font_pt` when `--link_mode` is `text`
- Document font-size-based row height scaling in README

## Testing
- `python -m py_compile auto_generate_ppt_xlwings_final_v2.py`
- `python auto_generate_ppt_xlwings_final_v2.py --help`

------
https://chatgpt.com/codex/tasks/task_e_689a2732db348331b3b9be0c4dc4321e