### PR TITLE
Clarify summary formula requirements and expose slide layout index

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ python auto_generate_ppt_openpyxl.py ^
   --link_mode overlay ^
   --table_font_pt 12 ^
   --round_digits 2 ^
+  --slide_layout_idx 5 ^
   --skip_cols 2 4 ^
   --verbose
 ```
@@ -70,8 +71,15 @@ python auto_generate_ppt_openpyxl.py ^
 - `--link_mode` : `text` (hyperlink on the number text; no shapes; **default**) or `overlay` (transparent rectangles on top of each numeric cell).
 - `--table_font_pt` : font size for table text (deprecated alias: `--header_font_pt`). When `--link_mode` is `text`, row heights scale with this value (0.4" at 18pt).
 - `--round_digits` : decimal places for numeric values (default 2).
+- `--slide_layout_idx` : index of the PowerPoint slide layout to use for generated slides (default 5).
 - `--skip_cols` : one-based indexes of data columns (excluding the key column) to skip linking.
 - `--verbose` : print debug info (useful while wiring up a new workbook).
+
+## Summary formula guidelines
+
+- Nested `SUM` and `FILTER` formulas are supported, e.g., `=SUM(FILTER(Raw_Data[Variants]*Raw_Data[Revenue per variant (USD)],Raw_Data[Category]=A12))`.
+- Summary formulas must pull from data structured as an Excel Table (ListObject).
+- Summary tables using `VLOOKUP` are untested and may not work.
 
 ---
 

--- a/auto_generate_ppt_openpyxl.py
+++ b/auto_generate_ppt_openpyxl.py
@@ -283,6 +283,7 @@ def build_ppt_openpyxl(
     round_digits: int = 2,
     pptx_in_path: Path = None,
     skip_col_idxs: list[int] | None = None,
+    slide_layout_idx: int = 5,
 ):
     wb_formula = load_workbook(xlsx_path, data_only=False)
     wb_values = load_workbook(xlsx_path, data_only=True)
@@ -336,7 +337,7 @@ def build_ppt_openpyxl(
         prs = Presentation(pptx_in_path) if pptx_in_path else Presentation()
         skip_set = set(skip_col_idxs or [])
         # Title Only layout
-        summary_slide = prs.slides.add_slide(prs.slide_layouts[5])
+        summary_slide = prs.slides.add_slide(prs.slide_layouts[slide_layout_idx])
         summary_slide.shapes.title.text = "Summary Table"
 
         # table scaffold aligned with title margins
@@ -413,7 +414,7 @@ def build_ppt_openpyxl(
                     df_filtered = df_raw[df_raw[key_col] == key_val]
                 df_snippet = df_filtered[cols_used].copy()
 
-                slide = prs.slides.add_slide(prs.slide_layouts[5])
+                slide = prs.slides.add_slide(prs.slide_layouts[slide_layout_idx])
                 slide.shapes.title.text = f"{key} – {metric}"
                 title_shape = slide.shapes.title
                 right_margin = prs.slide_width - (title_shape.left + title_shape.width)
@@ -532,6 +533,7 @@ def main():
     ap.add_argument("--table_font_pt", type=int, default=None, help="Font size for table text")
     ap.add_argument("--header_font_pt", type=int, default=None, help=argparse.SUPPRESS)
     ap.add_argument("--round_digits", type=int, default=2, help="Decimal places for numeric values")
+    ap.add_argument("--slide_layout_idx", type=int, default=5, help="Slide layout index for generated slides (default 5)")
     ap.add_argument("--verbose", action="store_true", help="Debug prints")
     ap.add_argument(
         "--skip_cols",
@@ -560,6 +562,7 @@ def main():
         round_digits=args.round_digits,
         pptx_in_path=Path(args.pptx_in) if args.pptx_in else None,
         skip_col_idxs=args.skip_cols,
+        slide_layout_idx=args.slide_layout_idx,
     )
     print(f"PPT created: {out}")
 


### PR DESCRIPTION
## Summary
- document supported nested `SUM`/`FILTER` formulas
- note requirement to reference Excel Tables in summary formulas
- mention `VLOOKUP` formulas are untested
- allow overriding slide layout with `--slide_layout_idx` (default 5)

## Testing
- `pip install -r requirements.txt`
- `python verify_pptx.py`


------
https://chatgpt.com/codex/tasks/task_e_689e1173cde88331b174b3ca333c0a43